### PR TITLE
adding cstdint to base64Layer to kill compilation error

### DIFF
--- a/src/paraviewo/base64Layer.hpp
+++ b/src/paraviewo/base64Layer.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <iostream>
+#include <cstdint>
 
 namespace paraviewo
 {


### PR DESCRIPTION
Was getting errors on ```gcc (Gentoo 13.2.1_p20230826 p7) 13.2.1 20230826``` that looked like:
```
In file included from /home/mtao/git/wildmeshing-toolkit/build/_deps/paraviewo-src/src/paraviewo/base64Layer.cpp:1:
/home/mtao/git/wildmeshing-toolkit/build/_deps/paraviewo-src/src/paraviewo/base64Layer.hpp:43:41: error: ‘uint64_t’ does not name a type
   43 |                 inline void write(const uint64_t v) { write(reinterpret_cast<const char *>(&v), sizeof(uint64_t)); }
      |                                         ^~~~~~~~
/home/mtao/git/wildmeshing-toolkit/build/_deps/paraviewo-src/src/paraviewo/base64Layer.hpp:4:1: note: ‘uint64_t’ is defined in header ‘<cstdint>’; did you forget to ‘#include <cstdint>’?
    3 | #include <iostream>
  +++ |+#include <cstdint>
    4 |
```

Just did the change requested by the compiler.