### PR TITLE
fix hdf5 cmake policy

### DIFF
--- a/cmake/recipes/hdf5.cmake
+++ b/cmake/recipes/hdf5.cmake
@@ -52,6 +52,12 @@ set(HDF5_RELEASE_TAG hdf5-1_14_3)
 #we fetch the zip file to get prebuilt files (and avoid a perl dependency)
 CPMAddPackage("https://github.com/HDFGroup/hdf5/releases/download/${HDF5_RELEASE_TAG}/${HDF5_RELEASE_TAG}.zip")
 
+# This cmake policy allows us to link target defined in other directory.
+# For unknown reason, this policy is set to OLD in polyFEM CI.
+if(POLICY CMP0079)
+      cmake_policy(SET CMP0079 NEW)
+endif()
 target_link_libraries(hdf5-static PUBLIC ZLIB::ZLIBSTATIC)
+
 target_link_libraries(hdf5-static INTERFACE hdf5_hl-static)
 add_library(hdf5::hdf5 ALIAS hdf5-static)


### PR DESCRIPTION
Set cmake policy 0079 to NEW. allows us to link target defined in other directory.
